### PR TITLE
Add Acme.sh client into base image

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,6 +45,7 @@ It does not matter if the damage is caused by incorrect usage or a bug in the so
 * All packages come from the following locations:
   * Offical RaspiOS package repo
   * moOde package build repo [pkgbuild](https://github.com/moode-player/pkgbuild)
+  * acme.sh (https://github.com/acmesh-official/acme.sh)
 * The host used for the build should be connected via Ethernet for best download performance from the remote repos
 
 ## Output

--- a/moode-cfg/stage2_04-moode-install_01-packages
+++ b/moode-cfg/stage2_04-moode-install_01-packages
@@ -84,6 +84,7 @@ trx
 # upmpdcli
 # upmpdcli-qobuz
 # upmpdcli-tidal
+vim
 winbind
 wsdd
 xfsprogs

--- a/moode-cfg/stage3_00-moode-install-prereq_00-run-chroot.sh
+++ b/moode-cfg/stage3_00-moode-install-prereq_00-run-chroot.sh
@@ -14,5 +14,19 @@ curl -1sLf \
 'https://dl.cloudsmith.io/public/moodeaudio/m8y/setup.deb.sh' \
 | sudo -E distro=raspbian codename=bookworm bash
 
+echo "Getting acme.sh repo"
+
+if [ -d "/root/acme.sh" ]; then
+  rm -rf /root/acme.sh
+fi
+
+wget -O /root/master.zip https://github.com/acmesh-official/acme.sh/archive/refs/heads/master.zip
+
+echo "unzip acme.sh repo"
+unzip /root/master.zip -d /root
+mv /root/acme.sh-master /root/acme.sh
+
+rm /root/master.zip
+
 echo "Update package lists"
 apt-get update


### PR DESCRIPTION
This PR adds [acme.sh](https://github.com/acmesh-official/acme.sh) into the base build.

In the short term it will enable advanced users to generate certificates using ACME bassed issuers (ZeroSSL and Let's Encrypt) in the longer term it should be possible to expose the acme.sh interface via the UI. It would be handy to have the client in place in advance of attempting to expose it via the UI.

I have also added Vim into the base packages as it is a much nicer editor to work with and isn't significantly larger.